### PR TITLE
Use `entry` when adding listeners

### DIFF
--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -84,17 +84,10 @@ impl<T> FnsAndTraits<T>
 where
     T: PartialEq + Eq + Hash + Clone + 'static,
 {
-    fn new_with_traits(trait_objects: Vec<Weak<RwLock<dyn Listener<T> + 'static>>>) -> Self {
-        FnsAndTraits {
-            traits: trait_objects,
-            fns: vec![],
-        }
-    }
-
-    fn new_with_fns(fns: EventFunction<T>) -> Self {
+    fn new() -> Self {
         FnsAndTraits {
             traits: vec![],
-            fns,
+            fns: vec![],
         }
     }
 }

--- a/src/rc/priority_dispatcher.rs
+++ b/src/rc/priority_dispatcher.rs
@@ -124,33 +124,13 @@ where
         listener: &Rc<RwLock<D>>,
         priority: P,
     ) {
-        if let Some(prioritised_listener_collection) = self.events.get_mut(&event_identifier) {
-            if let Some(priority_level_collection) =
-                prioritised_listener_collection.get_mut(&priority)
-            {
-                priority_level_collection.traits.push(Rc::downgrade(
-                    &(Rc::clone(listener) as Rc<RwLock<dyn Listener<T> + 'static>>),
-                ));
-
-                return;
-            }
-            prioritised_listener_collection.insert(
-                priority.clone(),
-                FnsAndTraits::new_with_traits(vec![Rc::downgrade(
-                    &(Rc::clone(listener) as Rc<RwLock<dyn Listener<T> + 'static>>),
-                )]),
-            );
-            return;
-        }
-
-        let mut b_tree_map = BTreeMap::new();
-        b_tree_map.insert(
-            priority,
-            FnsAndTraits::new_with_traits(vec![Rc::downgrade(
-                &(Rc::clone(listener) as Rc<RwLock<dyn Listener<T> + 'static>>),
-            )]),
-        );
-        self.events.insert(event_identifier, b_tree_map);
+        let prioritised_listener_collection = self.events.entry(event_identifier)
+            .or_insert(BTreeMap::new());
+        let priority_level_collection = prioritised_listener_collection.entry(priority)
+            .or_insert(FnsAndTraits::new());
+        priority_level_collection.traits.push(Rc::downgrade(
+            &(Rc::clone(listener) as Rc<RwLock<dyn Listener<T> + 'static>>),
+        ));
     }
 
     /// Adds an [`Fn`] to listen for an `event_identifier`, considering
@@ -212,22 +192,11 @@ where
         function: Box<dyn Fn(&T) -> Option<SyncDispatcherRequest>>,
         priority: P,
     ) {
-        if let Some(prioritised_listener_collection) = self.events.get_mut(&event_identifier) {
-            if let Some(priority_level_collection) =
-                prioritised_listener_collection.get_mut(&priority)
-            {
-                priority_level_collection.fns.push(function);
-
-                return;
-            }
-            prioritised_listener_collection
-                .insert(priority.clone(), FnsAndTraits::new_with_fns(vec![function]));
-            return;
-        }
-
-        let mut b_tree_map = BTreeMap::new();
-        b_tree_map.insert(priority, FnsAndTraits::new_with_fns(vec![function]));
-        self.events.insert(event_identifier, b_tree_map);
+        let prioritised_listener_collection = self.events.entry(event_identifier)
+            .or_insert(BTreeMap::new());
+        let priority_level_collection = prioritised_listener_collection.entry(priority)
+            .or_insert(FnsAndTraits::new());
+        priority_level_collection.fns.push(function);
     }
 
     /// All [`Listener`]s listening to a passed `event_identifier`

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -121,19 +121,10 @@ impl<T> FnsAndTraits<T>
 where
     T: PartialEq + Eq + Hash + Clone + Send + Sync + 'static,
 {
-    fn new_with_traits(
-        trait_objects: Vec<Weak<RwLock<dyn Listener<T> + Send + Sync + 'static>>>,
-    ) -> Self {
-        FnsAndTraits {
-            traits: trait_objects,
-            fns: vec![],
-        }
-    }
-
-    fn new_with_fns(fns: EventFunction<T>) -> Self {
+    fn new() -> Self {
         FnsAndTraits {
             traits: vec![],
-            fns,
+            fns: vec![],
         }
     }
 }
@@ -217,19 +208,10 @@ impl<T> ParallelFnsAndTraits<T>
 where
     T: PartialEq + Eq + Hash + Clone + Send + Sync + 'static,
 {
-    fn new_with_traits(
-        trait_objects: Vec<Weak<RwLock<dyn ParallelListener<T> + Send + Sync + 'static>>>,
-    ) -> Self {
-        ParallelFnsAndTraits {
-            traits: trait_objects,
-            fns: vec![],
-        }
-    }
-
-    fn new_with_fns(fns: ParallelEventFunction<T>) -> Self {
+    fn new() -> Self {
         ParallelFnsAndTraits {
             traits: vec![],
-            fns,
+            fns: vec![],
         }
     }
 }


### PR DESCRIPTION
Hello, thank you for your work on this crate!

I've been using this crate as a reference to create a dispatcher for my specialized use case (singlethreaded sync dispatcher supporting event types that include references). I've uploaded it [here](https://github.com/lcdr/event_dispatcher) if you want to take a look. While working on it, I've found some things that may also be of interest to you:

- If multithreading is not needed, it's possible to get this crate's transitive dependencies down from 120 to zero, by making multithreading an optional feature in Cargo.

- It's possible to extend the dispatcher's interface to accept not just closures, but any owned Listener, changing the dispatcher's dichotomy from traits vs fns to weakrefs vs owned. This is done through a blanket impl making all closures implement Listener.

- It's possible to further generalize this to get rid of the dichotomy altogether, through another blanket impl making all weakrefs to Listeners implement Listener. Through this, it's possible to view weakrefs not as weakrefs to listeners, but as owned listeners themselves. This gets rid of the FnsAndTraits type and a bunch of special casing can be removed.

- Finally, it's possible to add support for event types that hold references, but this unfortunately can't be done as elegantly. Reference-holding event types will be parametric over lifetimes. Due to how lifetime variance works in Rust, this requires using higher-ranked trait bounds, but these don't work with generics. However, it's possible to support them by using a macro that does the monomorphization manually. This is more of a workaround than a proper solution, so I don't propose doing this in this crate, but I still wanted to let you know.

(I've been limiting myself to single-threaded sync dispatchers, so it's possible that some of the above don't hold for other dispatchers.)

I've also found a smaller thing that I'm opening this pull request for: Adding a new listener to a dispatcher currently gets the matching event ID key from the HashMap, and if it doesn't exist, creates one. This can be replaced by [`entry`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry) which improves performance by avoiding an extra lookup if the key doesn't exist. It also allows removing a lot of duplicated code from the add methods.